### PR TITLE
[TOA-1137] Add bundle tool for acquiring version and versioname

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -9,4 +9,4 @@ RUN sudo make
 RUN sudo make install
 
 COPY --from=gcloudsdk263 /usr/local/bin/docker /usr/local/bin/docker
-ENV PATH "$PATH:/opt/google-cloud-sdk/bin/:/opt/android/sdk/build-tools/29.0.1"
+ENV PATH "$PATH:/opt/google-cloud-sdk/bin/:/opt/android/sdk/build-tools/29.0.3"

--- a/Dockerfile
+++ b/Dockerfile
@@ -3,6 +3,7 @@ FROM ccistaging/android:api-29
 
 WORKDIR /
 ADD git-crypt-0.6.0 git-crypt-0.6.0
+ADD bundletool-1.7.0 bundletool
 RUN sudo apt-get install libssl-dev
 WORKDIR /git-crypt-0.6.0
 RUN sudo make
@@ -10,3 +11,5 @@ RUN sudo make install
 
 COPY --from=gcloudsdk263 /usr/local/bin/docker /usr/local/bin/docker
 ENV PATH "$PATH:/opt/google-cloud-sdk/bin/:/opt/android/sdk/build-tools/29.0.3"
+
+# TODO build and run bundle tool. publish then start running lanes on it from ci experimental

--- a/Dockerfile
+++ b/Dockerfile
@@ -10,6 +10,6 @@ RUN sudo make
 RUN sudo make install
 
 COPY --from=gcloudsdk263 /usr/local/bin/docker /usr/local/bin/docker
-ENV PATH "$PATH:/opt/google-cloud-sdk/bin/:/opt/android/sdk/build-tools/29.0.3"
+ENV PATH "$PATH:/opt/google-cloud-sdk/bin/:/opt/android/sdk/build-tools/29.0.3:/opt/bundletool/"
 
 # TODO build and run bundle tool. publish then start running lanes on it from ci experimental

--- a/Dockerfile
+++ b/Dockerfile
@@ -3,6 +3,7 @@ FROM ccistaging/android:api-29
 
 WORKDIR /
 ADD git-crypt-0.6.0 git-crypt-0.6.0
+# Path for bundletool needs referencing directly as it is a jar
 ADD bundletool-1.7.0 bundletool
 RUN sudo apt-get install libssl-dev
 WORKDIR /git-crypt-0.6.0
@@ -10,6 +11,4 @@ RUN sudo make
 RUN sudo make install
 
 COPY --from=gcloudsdk263 /usr/local/bin/docker /usr/local/bin/docker
-ENV PATH "$PATH:/opt/google-cloud-sdk/bin/:/opt/android/sdk/build-tools/29.0.3:/opt/bundletool/"
-
-# TODO build and run bundle tool. publish then start running lanes on it from ci experimental
+ENV PATH=":/opt/google-cloud-sdk/bin/:/opt/android/sdk/build-tools/29.0.3:${PATH}"

--- a/README.md
+++ b/README.md
@@ -5,3 +5,4 @@ Docker container containing tooling for running firebase testlab on top of the a
 * API 29 Build tools.
 * gcloud sdk.
 * Exposes `aapt` as a path variable
+* Adds `bundletool` for reading meta information about `.aab` files


### PR DESCRIPTION
Adds bundletool (third party, doesn't come as a part of sdk tools).
Exposes jar for access to circle ci